### PR TITLE
Leap: update uavo metadata upon autopilot connect

### DIFF
--- a/ground/gcs/src/plugins/leapcontrol/leapcontrol.pro
+++ b/ground/gcs/src/plugins/leapcontrol/leapcontrol.pro
@@ -7,6 +7,7 @@ QT += network
 include(../../taulabsgcsplugin.pri) 
 include(../../plugins/coreplugin/coreplugin.pri) 
 include(../../plugins/uavobjects/uavobjects.pri)
+include(../../plugins/uavtalk/uavtalk.pri)
 include(leap.pri)
 
 HEADERS += leapcontrolgadget.h \

--- a/ground/gcs/src/plugins/leapcontrol/leapcontrolgadget.h
+++ b/ground/gcs/src/plugins/leapcontrol/leapcontrolgadget.h
@@ -28,6 +28,7 @@
 #define LEAPCONTROLGADGET_H
 
 #include <coreplugin/iuavgadget.h>
+#include "uavtalk/telemetrymanager.h"
 #include "leapcontrolplugin.h"
 #include "leapcontrol.h"
 #include <QTimer>
@@ -58,6 +59,10 @@ private:
     LeapControl * m_leapControl;
 
 signals:
+
+private slots:
+    void onAutopilotConnect();
+    void onAutopilotDisconnect();
 
 protected slots:
     void handUpdated(bool present, double x, double y, double z, double roll, double pitch, double yaw);


### PR DESCRIPTION
One less thing to worry about to make Leap control work: make the GCS send leapmotion updates to the flight controller every 30ms upon autopilot connection
