### PR TITLE
Fix metadata update issues

### DIFF
--- a/ground/gcs/src/plugins/config/calibration.h
+++ b/ground/gcs/src/plugins/config/calibration.h
@@ -149,9 +149,6 @@ private:
     //! Slow all the other data updates
     void slowDataUpdates();
 
-    //! Slow all the other data updates
-    void setDataUpdates();
-
     //! Perform the leveling calculation
     void doStartLeveling();
 
@@ -163,6 +160,10 @@ private:
 
     //! Assign the metadata update rate
     void assignUpdateRate(UAVObject* obj, quint32 updatePeriod);
+
+    //! Slow the metadata update rate
+    void slowUpdateRate(UAVObject* obj);
+
 
     QTimer timer;
 
@@ -182,7 +183,7 @@ private:
     QMap<QString, UAVObject::Metadata> originalMetaData;
 
     //! List of optimized metadata rates
-    QMap<QString, UAVObject::Metadata> metaDataList;
+    QMap<QString, UAVObject::Metadata> slowedDownMetaDataList;
 
     QList<double> gyro_accum_x;
     QList<double> gyro_accum_y;
@@ -203,7 +204,7 @@ private:
     static const int NUM_SENSOR_UPDATES_YAW_ORIENTATION = 300;
     static const int NUM_SENSOR_UPDATES_SIX_POINT = 100;
     static const int SENSOR_UPDATE_PERIOD = 20;
-    static const int NON_SENSOR_UPDATE_PERIOD = 5000;
+    static const int NON_SENSOR_UPDATE_PERIOD = 0;
     double MIN_TEMPERATURE_RANGE;
 
     double initialBoardRotation[3];

--- a/ground/gcs/src/plugins/uavobjectutil/uavobjectutilmanager.h
+++ b/ground/gcs/src/plugins/uavobjectutil/uavobjectutilmanager.h
@@ -94,12 +94,9 @@ private:
     UAVObjectManager *obm;
     UAVObjectUtilManager *obum;
     QMap<UAVDataObject*, UAVObject::Metadata> metadataSendlist;
-    QTimer metadataSendTimeout;
     bool metadataSendSuccess;
-    int metadataSendRetries;
     QErrorMessage *incompatibleMsg;
 private slots:
-    void onMetadataSendTimeout();
     void objectPersistenceTransactionCompleted(UAVObject* obj, bool success);
     void objectPersistenceUpdated(UAVObject * obj);
     void objectPersistenceOperationFailed();

--- a/ground/gcs/src/plugins/uavtalk/telemetry.cpp
+++ b/ground/gcs/src/plugins/uavtalk/telemetry.cpp
@@ -366,13 +366,14 @@ void Telemetry::transactionTimeout(ObjectTransactionInfo *transInfo)
     // Check if more retries are pending
     if (transInfo->retriesRemaining > 0)
     {
-        TELEMETRY_QXTLOG_DEBUG(QString("[telemetry.cpp] Transaction timeout:%0 Instance:%1").arg(transInfo->obj->getName() + QString(QString(" 0x") + QString::number(transInfo->obj->getObjID(), 16).toUpper())).arg(transInfo->obj->getInstID()));
+        TELEMETRY_QXTLOG_DEBUG(QString("[telemetry.cpp] Transaction timeout:%0 Instance:%1 Retrying").arg(transInfo->obj->getName() + QString(QString(" 0x") + QString::number(transInfo->obj->getObjID(), 16).toUpper())).arg(transInfo->obj->getInstID()));
         --transInfo->retriesRemaining;
         processObjectTransaction(transInfo);
         ++txRetries;
     }
     else
     {
+        TELEMETRY_QXTLOG_DEBUG(QString("[telemetry.cpp] Transaction timeout:%0 Instance:%1 no more retries. FAILED TRANSACT").arg(transInfo->obj->getName() + QString(QString(" 0x") + QString::number(transInfo->obj->getObjID(), 16).toUpper())).arg(transInfo->obj->getInstID()));
         transInfo->timer->stop();
         transactionFailure(transInfo->obj);
         ++txErrors;


### PR DESCRIPTION
Basically the great misconception was connecting a transactionCompleted completed signal from a UAVDataObject and expect it to fire by setting obj->setMetaData... the signal that fires in that situation is the UAVDataObject's UAVMetaObject transactionCompleted. 
That is why the old code had the strange "obj->Updated" there, it was a workaround to make that signal fire but made no sense since that only proved the obj data had went through and not the metadata we wanted. It also caused more delay since there was an unwanted send and wait for ack operation.
